### PR TITLE
Reformat with ruff

### DIFF
--- a/pyspcbridge/area.py
+++ b/pyspcbridge/area.py
@@ -1,13 +1,15 @@
 import logging
 
 from .const import ArmMode
-from .lib.utils import _load_enum
 from .lib.spc_error import SpcError
+from .lib.utils import _load_enum
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class Area:
     """Represents a SPC area."""
+
     def __init__(self, bridge, area_data):
         self._bridge = bridge
         self._id = area_data.get("id")
@@ -165,9 +167,13 @@ class Area:
             return SpcError(54).error
 
         if command == "clear_alerts":
-            return await self._http_client.async_command_clear_alerts(username, password)
+            return await self._http_client.async_command_clear_alerts(
+                username, password
+            )
         else:
-            err = await self._http_client.async_command_area(command, self._id, username, password)
+            err = await self._http_client.async_command_area(
+                command, self._id, username, password
+            )
             if command == "set_delayed" and err["code"] == 0:
                 self._bridge.set_value("area", self._id, {"pending_exit": True})
             else:
@@ -175,4 +181,4 @@ class Area:
             return err
 
     async def async_get_arm_status(self, arm_mode) -> dict:
-        return await self._http_client.async_get_area_arm_status(arm_mode, self,_id)
+        return await self._http_client.async_get_area_arm_status(arm_mode, self, _id)

--- a/pyspcbridge/const.py
+++ b/pyspcbridge/const.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class ArmMode(Enum):
     UNSET = 0
     PART_SET_A = 1
@@ -54,6 +55,7 @@ class ZoneType(Enum):
     CO = 29
     ENTRY_EXIT_2 = 30
 
+
 class ZoneStatus(Enum):
     OK = 0
     INHIBIT = 1
@@ -64,8 +66,8 @@ class ZoneStatus(Enum):
     OK_NOT_RECENT = 6
     TROUBLE = 7
 
+
 class DoorMode(Enum):
     NORMAL = 0
     LOCKED = 1
     UNLOCKED = 2
-

--- a/pyspcbridge/door.py
+++ b/pyspcbridge/door.py
@@ -1,8 +1,10 @@
 import logging
+
 _LOGGER = logging.getLogger(__name__)
-from .lib.utils import _load_enum
-from .lib.spc_error import SpcError
 from .const import DoorMode
+from .lib.spc_error import SpcError
+from .lib.utils import _load_enum
+
 
 class Door:
     """Represents a SPC door lock."""
@@ -71,4 +73,6 @@ class Door:
         if username is None or password is None:
             return SpcError(54).error
 
-        return await self._http_client.async_command_door(command, self._id, username, password)
+        return await self._http_client.async_command_door(
+            command, self._id, username, password
+        )

--- a/pyspcbridge/output.py
+++ b/pyspcbridge/output.py
@@ -1,6 +1,8 @@
 import logging
+
 _LOGGER = logging.getLogger(__name__)
 from .lib.spc_error import SpcError
+
 
 class Output:
     """Represents a SPC output/mapping gate."""
@@ -24,7 +26,7 @@ class Output:
 
     @property
     def state(self) -> bool:
-        return self._values["state"] 
+        return self._values["state"]
 
     def change_values(self, values) -> list:
         changed_values = []
@@ -36,7 +38,6 @@ class Output:
 
         return changed_values
 
-
     async def async_command(self, command, code) -> int:
         if code is None:
             return SpcError(54).error
@@ -47,4 +48,6 @@ class Output:
         if username is None or password is None:
             return SpcError(54).error
 
-        return await self._http_client.async_command_output(command, self._id, username, password)
+        return await self._http_client.async_command_output(
+            command, self._id, username, password
+        )

--- a/pyspcbridge/panel.py
+++ b/pyspcbridge/panel.py
@@ -1,23 +1,23 @@
 import logging
 
 from .const import ArmMode
-from .lib.utils import _load_enum
 from .lib.spc_error import SpcError
+from .lib.utils import _load_enum
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class Panel:
     """Represents a SPC panel."""
 
     def __init__(self, bridge, panel_data, areas):
-
         self._bridge = bridge
         self._id = panel_data.get("serial")
         self._type = panel_data.get("type")
         self._model = panel_data.get("model")
         self._serial = panel_data.get("serial")
         self._firmware = panel_data.get("firmware")
-        self._pincode_length = int(panel_data.get("pincode_length",0))
+        self._pincode_length = int(panel_data.get("pincode_length", 0))
         self._http_client = bridge._http_client
         self._values = {
             "event": "",
@@ -104,7 +104,7 @@ class Panel:
     @property
     def values(self):
         return self._values
- 
+
     def change_values(self, values) -> list:
         changed_values = []
         if values.get("event") != None:
@@ -120,7 +120,7 @@ class Panel:
         _mode = None
         for a in self._areas:
             _area_mode = a.mode
-            if  _mode == None:
+            if _mode == None:
                 _mode = _area_mode
             elif _area_mode.value != _mode.value:
                 _m = _mode
@@ -190,9 +190,13 @@ class Panel:
                 return SpcError(54).error
 
         if command == "clear_alerts":
-            return await self._http_client.async_command_clear_alerts(username, password)
+            return await self._http_client.async_command_clear_alerts(
+                username, password
+            )
         else:
-            err = await self._http_client.async_command_area(command, None, username, password)
+            err = await self._http_client.async_command_area(
+                command, None, username, password
+            )
             if command == "set_delayed":
                 if isinstance(err, dict) and err.get("code", 0) > 0:
                     return err

--- a/pyspcbridge/user.py
+++ b/pyspcbridge/user.py
@@ -1,5 +1,7 @@
 import logging
+
 _LOGGER = logging.getLogger(__name__)
+
 
 class User:
     """Represents a SPC user."""
@@ -29,4 +31,3 @@ class User:
     @property
     def spc_password(self):
         return self._spc_password
-

--- a/pyspcbridge/zone.py
+++ b/pyspcbridge/zone.py
@@ -1,10 +1,11 @@
 import logging
 
 from .const import ZoneInput, ZoneStatus, ZoneType
-from .lib.utils import _load_enum
 from .lib.spc_error import SpcError
+from .lib.utils import _load_enum
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class Zone:
     """Represents a SPC zone."""
@@ -73,8 +74,12 @@ class Zone:
         if zone_status == ZoneStatus.TAMPER:
             _alarm_status["tamper"] = True
         elif zone_status == ZoneStatus.ALARM:
-            if (zone_type == ZoneType.ALARM or zone_type == ZoneType.ENTRY_EXIT or 
-                zone_type == ZoneType.GLASSBREAK or zone_type == ZoneType.ENTRY_EXIT_2):
+            if (
+                zone_type == ZoneType.ALARM
+                or zone_type == ZoneType.ENTRY_EXIT
+                or zone_type == ZoneType.GLASSBREAK
+                or zone_type == ZoneType.ENTRY_EXIT_2
+            ):
                 _alarm_status["intrusion"] = True
             elif zone_type == ZoneType.FIRE:
                 _alarm_status["fire"] = True
@@ -82,7 +87,7 @@ class Zone:
                 _alarm_status["tamper"] = True
 
         if zone_input != ZoneInput.CLOSED and zone_input != ZoneInput.OPEN:
-           _alarm_status["problem"] = True
+            _alarm_status["problem"] = True
 
         return _alarm_status
 
@@ -120,5 +125,6 @@ class Zone:
         if username is None or password is None:
             return SpcError(54).error
 
-        return await self._http_client.async_command_zone(command, self._id, username, password)
-
+        return await self._http_client.async_command_zone(
+            command, self._id, username, password
+        )


### PR DESCRIPTION
Needs #3, but provided as separate PR for readability. Formatting with `ruff` is de-facto standard (and compatibly with `black` and `isort`) and most IDEs has built-in support for maintaining formatting. The pre-commit hook introduced in #3 also helps.

Updates #1 